### PR TITLE
Add --append-config cli option

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -80,6 +80,11 @@ All options available as of Flake8 3.1.0::
     --output-file=OUTPUT_FILE
                           Redirect report to a file.
     --tee                 Write to stdout and output-file.
+    --prepend-config=PREPEND_CONFIG
+                          Provide extra config files to parse in addition to the
+                          files found by Flake8 by default. These files are the
+                          first ones read and so they take the lowest precedence
+                          when multiple files provide the same option.
     --append-config=APPEND_CONFIG
                           Provide extra config files to parse in addition to the
                           files found by Flake8 by default. These files are the

--- a/docs/source/user/invocation.rst
+++ b/docs/source/user/invocation.rst
@@ -126,6 +126,11 @@ And you should see something like:
       --output-file=OUTPUT_FILE
                             Redirect report to a file.
       --tee                 Write to stdout and output-file.
+      --prepend-config=PREPEND_CONFIG
+                            Provide extra config files to parse in addition to the
+                            files found by Flake8 by default. These files are the
+                            first ones read and so they take the lowest precedence
+                            when multiple files provide the same option.
       --append-config=APPEND_CONFIG
                             Provide extra config files to parse in addition to the
                             files found by Flake8 by default. These files are the

--- a/docs/source/user/options.rst
+++ b/docs/source/user/options.rst
@@ -78,6 +78,8 @@ Index of Options
 
 - :option:`flake8 --tee`
 
+- :option:`flake8 --prepend-config`
+
 - :option:`flake8 --append-config`
 
 - :option:`flake8 --config`
@@ -704,6 +706,27 @@ Options and their Descriptions
 
         output-file = output.txt
         tee = True
+
+
+.. option:: --prepend-config=<config>
+
+    :ref:`Go back to index <top>`
+
+    Provide extra config files to parse in before and in addition to the files
+    that |Flake8| found on its own. Since these files are the first ones read
+    into the Configuration Parser, they have the lowest precedence if it
+    provides an option specified in another config file.
+
+    Typical use is to specify cross-project options that can still be
+    overridden by user or project config files.
+
+    Command-line example:
+
+    .. prompt:: bash
+
+        flake8 --prepend-config=my-default-config.ini dir/
+
+    This **can not** be specified in config files.
 
 
 .. option:: --append-config=<config>

--- a/src/flake8/__init__.py
+++ b/src/flake8/__init__.py
@@ -15,7 +15,7 @@ import sys
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
-__version__ = '3.5.0'
+__version__ = '3.5.0-append-config0'
 __version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
 
 

--- a/src/flake8/__init__.py
+++ b/src/flake8/__init__.py
@@ -15,7 +15,7 @@ import sys
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
-__version__ = '3.5.0-append-config0'
+__version__ = '3.6.0-append-config0'
 __version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
 
 

--- a/src/flake8/__init__.py
+++ b/src/flake8/__init__.py
@@ -15,7 +15,7 @@ import sys
 LOG = logging.getLogger(__name__)
 LOG.addHandler(logging.NullHandler())
 
-__version__ = '3.6.0-append-config0'
+__version__ = '3.6.0.append-config1'
 __version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
 
 

--- a/src/flake8/main/application.py
+++ b/src/flake8/main/application.py
@@ -152,11 +152,14 @@ class Application(object):
     def make_config_finder(self):
         """Make our ConfigFileFinder based on preliminary opts and args."""
         if self.config_finder is None:
+            prepend_config_files = utils.normalize_paths(
+                self.prelim_opts.prepend_config)
             extra_config_files = utils.normalize_paths(
                 self.prelim_opts.append_config)
             self.config_finder = config.ConfigFileFinder(
                 self.option_manager.program_name,
                 self.prelim_args,
+                prepend_config_files,
                 extra_config_files,
             )
 

--- a/src/flake8/main/options.py
+++ b/src/flake8/main/options.py
@@ -183,6 +183,14 @@ def register_default_options(option_manager):
     # Config file options
 
     add_option(
+        '--prepend-config', action='append',
+        help='Provide extra config files to parse in addition to the files '
+             'found by Flake8 by default. These files are the first ones read '
+             'and so they take the lowest precedence when multiple files '
+             'provide the same option.',
+    )
+
+    add_option(
         '--append-config', action='append',
         help='Provide extra config files to parse in addition to the files '
              'found by Flake8 by default. These files are the last ones read '

--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -1,6 +1,7 @@
 """Config handling logic for Flake8."""
 import collections
 import configparser
+import itertools
 import logging
 import os.path
 import sys
@@ -124,10 +125,10 @@ class ConfigFileFinder(object):
             [str]
         """
         exists = os.path.exists
-        return [f for f in self.prepend_config_files if exists(f)] + [
-            filename
-            for filename in self.generate_possible_local_files()
-        ] + [f for f in self.extra_config_files if exists(f)]
+        prepend_files = filter(exists, self.prepend_config_files)
+        local_files = self.generate_possible_local_files()
+        append_files = filter(exists, self.extra_config_files)
+        return itertools.chain(prepend_files, local_files, append_files)
 
     def local_configs(self):
         """Parse all local config files into one config object."""

--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -18,7 +18,10 @@ class ConfigFileFinder(object):
 
     PROJECT_FILENAMES = ('setup.cfg', 'tox.ini')
 
-    def __init__(self, program_name, args, prepend_config_files, extra_config_files):
+    def __init__(
+            self, program_name, args,
+            prepend_config_files, extra_config_files
+    ):
         """Initialize object to find config files.
 
         :param str program_name:
@@ -26,9 +29,11 @@ class ConfigFileFinder(object):
         :param list args:
             The extra arguments passed on the command-line.
         :param list prepend_config_files:
-            Extra configuration files specified by the user to read before user and project configs.
+            Extra configuration files specified by the user to read before user
+            and project configs.
         :param list extra_config_files:
-            Extra configuration files specified by the user to read after user and project configs.
+            Extra configuration files specified by the user to read after user
+            and project configs.
         """
         # The values of --prepend-config from the CLI
         prepend_config_files = prepend_config_files or []

--- a/src/flake8/options/config.py
+++ b/src/flake8/options/config.py
@@ -17,16 +17,25 @@ class ConfigFileFinder(object):
 
     PROJECT_FILENAMES = ('setup.cfg', 'tox.ini')
 
-    def __init__(self, program_name, args, extra_config_files):
+    def __init__(self, program_name, args, prepend_config_files, extra_config_files):
         """Initialize object to find config files.
 
         :param str program_name:
             Name of the current program (e.g., flake8).
         :param list args:
             The extra arguments passed on the command-line.
+        :param list prepend_config_files:
+            Extra configuration files specified by the user to read before user and project configs.
         :param list extra_config_files:
-            Extra configuration files specified by the user to read.
+            Extra configuration files specified by the user to read after user and project configs.
         """
+        # The values of --prepend-config from the CLI
+        prepend_config_files = prepend_config_files or []
+        self.prepend_config_files = [
+            # Ensure the paths are absolute paths for local_config_files
+            os.path.abspath(f) for f in prepend_config_files
+        ]
+
         # The values of --append-config from the CLI
         extra_config_files = extra_config_files or []
         self.extra_config_files = [
@@ -115,7 +124,7 @@ class ConfigFileFinder(object):
             [str]
         """
         exists = os.path.exists
-        return [
+        return [f for f in self.prepend_config_files if exists(f)] + [
             filename
             for filename in self.generate_possible_local_files()
         ] + [f for f in self.extra_config_files if exists(f)]

--- a/tests/integration/test_aggregator.py
+++ b/tests/integration/test_aggregator.py
@@ -26,7 +26,7 @@ def test_aggregate_options_with_config(optmanager):
     """Verify we aggregate options and config values appropriately."""
     arguments = ['flake8', '--config', CLI_SPECIFIED_CONFIG, '--select',
                  'E11,E34,E402,W,F', '--exclude', 'tests/*']
-    config_finder = config.ConfigFileFinder('flake8', arguments, [])
+    config_finder = config.ConfigFileFinder('flake8', arguments, [], [])
     options, args = aggregator.aggregate_options(
         optmanager, config_finder, arguments)
 
@@ -40,7 +40,7 @@ def test_aggregate_options_when_isolated(optmanager):
     """Verify we aggregate options and config values appropriately."""
     arguments = ['flake8', '--isolated', '--select', 'E11,E34,E402,W,F',
                  '--exclude', 'tests/*']
-    config_finder = config.ConfigFileFinder('flake8', arguments, [])
+    config_finder = config.ConfigFileFinder('flake8', arguments, [], [])
     optmanager.extend_default_ignore(['E8'])
     options, args = aggregator.aggregate_options(
         optmanager, config_finder, arguments)

--- a/tests/unit/test_config_file_finder.py
+++ b/tests/unit/test_config_file_finder.py
@@ -113,33 +113,13 @@ def test_generate_possible_local_files(args, expected):
         (['flake8/'],
             [CLI_SPECIFIED_FILEPATH],
             [],
-            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-                os.path.abspath('setup.cfg'),
-                os.path.abspath('tox.ini')]),
-        # Common prefix of "flake8/" with missing prepend config files
-        (['flake8/'],
-            [CLI_SPECIFIED_FILEPATH,
-                'tests/fixtures/config_files/missing.ini'],
-            [],
-            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-                os.path.abspath('setup.cfg'),
+            [os.path.abspath('setup.cfg'),
                 os.path.abspath('tox.ini')]),
         # Common prefix of "flake8/" with prepend and extra config files
         (['flake8/'],
             [CLI_SPECIFIED_FILEPATH],
             [CLI_SPECIFIED_FILEPATH],
-            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-                os.path.abspath('setup.cfg'),
-                os.path.abspath('tox.ini'),
-                os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
-        # Common prefix of "flake8/" with missing prepend and extra config
-        (['flake8/'],
-            [CLI_SPECIFIED_FILEPATH,
-                'tests/fixtures/config_files/missing1.ini'],
-            [CLI_SPECIFIED_FILEPATH,
-                'tests/fixtures/config_files/missing2.ini'],
-            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-                os.path.abspath('setup.cfg'),
+            [os.path.abspath('setup.cfg'),
                 os.path.abspath('tox.ini'),
                 os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
     ])
@@ -152,6 +132,63 @@ def test_local_config_files(
     )
 
     assert list(finder.local_config_files()) == expected
+
+
+@pytest.mark.parametrize(
+    'args,prepend_config_files,extra_config_files,expected', [
+        # No arguments, common prefix of abspath('.')
+        ([],
+            [],
+            [],
+            []),
+        # Common prefix of "flake8/"
+        (['flake8/options', 'flake8/'],
+            [],
+            [],
+            []),
+        # Common prefix of "flake8/options"
+        (['flake8/options', 'flake8/options/sub'],
+            [],
+            [],
+            []),
+        # Common prefix of "flake8/" with extra config files specified
+        (['flake8/'],
+            [],
+            [CLI_SPECIFIED_FILEPATH],
+            []),
+        # Common prefix of "flake8/" with prepend config files specified
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH],
+            [],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with missing prepend config files
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing.ini'],
+            [],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with prepend and extra config files
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH],
+            [CLI_SPECIFIED_FILEPATH],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with missing prepend and extra config
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing1.ini'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing2.ini'],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+    ])
+def test_prepend_config_files(
+        args, prepend_config_files, extra_config_files, expected
+):
+    """Verify discovery of local config files."""
+    finder = config.ConfigFileFinder(
+        'flake8', args, prepend_config_files, extra_config_files
+    )
+
+    assert list(finder.prepend_config_files()) == expected
 
 
 def test_local_configs():

--- a/tests/unit/test_config_file_finder.py
+++ b/tests/unit/test_config_file_finder.py
@@ -74,77 +74,82 @@ def test_generate_possible_local_files(args, expected):
             expected)
 
 
-@pytest.mark.parametrize('args,prepend_config_files,extra_config_files,expected', [
-    # No arguments, common prefix of abspath('.')
-    ([],
-        [],
-        [],
-        [os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini')]),
-    # Common prefix of "flake8/"
-    (['flake8/options', 'flake8/'],
-        [],
-        [],
-        [os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini')]),
-    # Common prefix of "flake8/options"
-    (['flake8/options', 'flake8/options/sub'],
-        [],
-        [],
-        [os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini')]),
-    # Common prefix of "flake8/" with extra config files specified
-    (['flake8/'],
-        [],
-        [CLI_SPECIFIED_FILEPATH],
-        [os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini'),
-            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
-    # Common prefix of "flake8/" with missing extra config files specified
-    (['flake8/'],
-        [],
-        [CLI_SPECIFIED_FILEPATH,
-            'tests/fixtures/config_files/missing.ini'],
-        [os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini'),
-            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
-    # Common prefix of "flake8/" with prepend config files specified
-    (['flake8/'],
-        [CLI_SPECIFIED_FILEPATH],
-        [],
-        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-            os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini')]),
-    # Common prefix of "flake8/" with missing prepend config files specified
-    (['flake8/'],
-        [CLI_SPECIFIED_FILEPATH,
-            'tests/fixtures/config_files/missing.ini'],
-        [],
-        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-            os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini')]),
-    # Common prefix of "flake8/" with prepend and extra config files specified
-    (['flake8/'],
-        [CLI_SPECIFIED_FILEPATH],
-        [CLI_SPECIFIED_FILEPATH],
-        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-            os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini'),
-            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
-    # Common prefix of "flake8/" with missing prepend and extra config files specified
-    (['flake8/'],
-        [CLI_SPECIFIED_FILEPATH,
-            'tests/fixtures/config_files/missing1.ini'],
-        [CLI_SPECIFIED_FILEPATH,
-            'tests/fixtures/config_files/missing2.ini'],
-        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
-            os.path.abspath('setup.cfg'),
-            os.path.abspath('tox.ini'),
-            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
-])
-def test_local_config_files(args, prepend_config_files, extra_config_files, expected):
+@pytest.mark.parametrize(
+    'args,prepend_config_files,extra_config_files,expected', [
+        # No arguments, common prefix of abspath('.')
+        ([],
+            [],
+            [],
+            [os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini')]),
+        # Common prefix of "flake8/"
+        (['flake8/options', 'flake8/'],
+            [],
+            [],
+            [os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini')]),
+        # Common prefix of "flake8/options"
+        (['flake8/options', 'flake8/options/sub'],
+            [],
+            [],
+            [os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini')]),
+        # Common prefix of "flake8/" with extra config files specified
+        (['flake8/'],
+            [],
+            [CLI_SPECIFIED_FILEPATH],
+            [os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini'),
+                os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with missing extra config files specified
+        (['flake8/'],
+            [],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing.ini'],
+            [os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini'),
+                os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with prepend config files specified
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH],
+            [],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+                os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini')]),
+        # Common prefix of "flake8/" with missing prepend config files
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing.ini'],
+            [],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+                os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini')]),
+        # Common prefix of "flake8/" with prepend and extra config files
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH],
+            [CLI_SPECIFIED_FILEPATH],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+                os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini'),
+                os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+        # Common prefix of "flake8/" with missing prepend and extra config
+        (['flake8/'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing1.ini'],
+            [CLI_SPECIFIED_FILEPATH,
+                'tests/fixtures/config_files/missing2.ini'],
+            [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+                os.path.abspath('setup.cfg'),
+                os.path.abspath('tox.ini'),
+                os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+    ])
+def test_local_config_files(
+        args, prepend_config_files, extra_config_files, expected
+):
     """Verify discovery of local config files."""
-    finder = config.ConfigFileFinder('flake8', args, prepend_config_files, extra_config_files)
+    finder = config.ConfigFileFinder(
+        'flake8', args, prepend_config_files, extra_config_files
+    )
 
     assert list(finder.local_config_files()) == expected
 

--- a/tests/unit/test_config_file_finder.py
+++ b/tests/unit/test_config_file_finder.py
@@ -15,7 +15,7 @@ BROKEN_CONFIG_PATH = 'tests/fixtures/config_files/broken.ini'
 
 def test_uses_default_args():
     """Show that we default the args value."""
-    finder = config.ConfigFileFinder('flake8', None, [])
+    finder = config.ConfigFileFinder('flake8', None, [], [])
     assert finder.parent == os.path.abspath('.')
 
 
@@ -27,14 +27,14 @@ def test_uses_default_args():
 def test_windows_detection(platform, is_windows):
     """Verify we detect Windows to the best of our knowledge."""
     with mock.patch.object(sys, 'platform', platform):
-        finder = config.ConfigFileFinder('flake8', None, [])
+        finder = config.ConfigFileFinder('flake8', None, [], [])
     assert finder.is_windows is is_windows
 
 
 def test_cli_config():
     """Verify opening and reading the file specified via the cli."""
     cli_filepath = CLI_SPECIFIED_FILEPATH
-    finder = config.ConfigFileFinder('flake8', None, [])
+    finder = config.ConfigFileFinder('flake8', None, [], [])
 
     parsed_config = finder.cli_config(cli_filepath)
     assert parsed_config.has_section('flake8')
@@ -42,7 +42,7 @@ def test_cli_config():
 
 def test_cli_config_double_read():
     """Second request for CLI config is cached."""
-    finder = config.ConfigFileFinder('flake8', None, [])
+    finder = config.ConfigFileFinder('flake8', None, [], [])
 
     parsed_config = finder.cli_config(CLI_SPECIFIED_FILEPATH)
     boom = Exception("second request for CLI config not cached")
@@ -68,59 +68,97 @@ def test_cli_config_double_read():
 ])
 def test_generate_possible_local_files(args, expected):
     """Verify generation of all possible config paths."""
-    finder = config.ConfigFileFinder('flake8', args, [])
+    finder = config.ConfigFileFinder('flake8', args, [], [])
 
     assert (list(finder.generate_possible_local_files()) ==
             expected)
 
 
-@pytest.mark.parametrize('args,extra_config_files,expected', [
+@pytest.mark.parametrize('args,prepend_config_files,extra_config_files,expected', [
     # No arguments, common prefix of abspath('.')
     ([],
+        [],
         [],
         [os.path.abspath('setup.cfg'),
             os.path.abspath('tox.ini')]),
     # Common prefix of "flake8/"
     (['flake8/options', 'flake8/'],
         [],
+        [],
         [os.path.abspath('setup.cfg'),
             os.path.abspath('tox.ini')]),
     # Common prefix of "flake8/options"
     (['flake8/options', 'flake8/options/sub'],
         [],
+        [],
         [os.path.abspath('setup.cfg'),
             os.path.abspath('tox.ini')]),
     # Common prefix of "flake8/" with extra config files specified
     (['flake8/'],
+        [],
         [CLI_SPECIFIED_FILEPATH],
         [os.path.abspath('setup.cfg'),
             os.path.abspath('tox.ini'),
             os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
     # Common prefix of "flake8/" with missing extra config files specified
     (['flake8/'],
+        [],
         [CLI_SPECIFIED_FILEPATH,
             'tests/fixtures/config_files/missing.ini'],
         [os.path.abspath('setup.cfg'),
             os.path.abspath('tox.ini'),
             os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+    # Common prefix of "flake8/" with prepend config files specified
+    (['flake8/'],
+        [CLI_SPECIFIED_FILEPATH],
+        [],
+        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+            os.path.abspath('setup.cfg'),
+            os.path.abspath('tox.ini')]),
+    # Common prefix of "flake8/" with missing prepend config files specified
+    (['flake8/'],
+        [CLI_SPECIFIED_FILEPATH,
+            'tests/fixtures/config_files/missing.ini'],
+        [],
+        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+            os.path.abspath('setup.cfg'),
+            os.path.abspath('tox.ini')]),
+    # Common prefix of "flake8/" with prepend and extra config files specified
+    (['flake8/'],
+        [CLI_SPECIFIED_FILEPATH],
+        [CLI_SPECIFIED_FILEPATH],
+        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+            os.path.abspath('setup.cfg'),
+            os.path.abspath('tox.ini'),
+            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
+    # Common prefix of "flake8/" with missing prepend and extra config files specified
+    (['flake8/'],
+        [CLI_SPECIFIED_FILEPATH,
+            'tests/fixtures/config_files/missing1.ini'],
+        [CLI_SPECIFIED_FILEPATH,
+            'tests/fixtures/config_files/missing2.ini'],
+        [os.path.abspath(CLI_SPECIFIED_FILEPATH),
+            os.path.abspath('setup.cfg'),
+            os.path.abspath('tox.ini'),
+            os.path.abspath(CLI_SPECIFIED_FILEPATH)]),
 ])
-def test_local_config_files(args, extra_config_files, expected):
+def test_local_config_files(args, prepend_config_files, extra_config_files, expected):
     """Verify discovery of local config files."""
-    finder = config.ConfigFileFinder('flake8', args, extra_config_files)
+    finder = config.ConfigFileFinder('flake8', args, prepend_config_files, extra_config_files)
 
     assert list(finder.local_config_files()) == expected
 
 
 def test_local_configs():
     """Verify we return a ConfigParser."""
-    finder = config.ConfigFileFinder('flake8', None, [])
+    finder = config.ConfigFileFinder('flake8', None, [], [])
 
     assert isinstance(finder.local_configs(), configparser.RawConfigParser)
 
 
 def test_local_configs_double_read():
     """Second request for local configs is cached."""
-    finder = config.ConfigFileFinder('flake8', None, [])
+    finder = config.ConfigFileFinder('flake8', None, [], [])
 
     first_read = finder.local_configs()
     boom = Exception("second request for local configs not cached")

--- a/tests/unit/test_get_local_plugins.py
+++ b/tests/unit/test_get_local_plugins.py
@@ -31,7 +31,7 @@ def test_get_local_plugins_uses_cli_config():
 def test_get_local_plugins():
     """Verify get_local_plugins returns expected plugins."""
     config_fixture_path = 'tests/fixtures/config_files/local-plugin.ini'
-    config_finder = config.ConfigFileFinder('flake8', [], [])
+    config_finder = config.ConfigFileFinder('flake8', [], [], [])
 
     with mock.patch.object(config_finder, 'local_config_files') as localcfs:
         localcfs.return_value = [config_fixture_path]

--- a/tests/unit/test_merged_config_parser.py
+++ b/tests/unit/test_merged_config_parser.py
@@ -17,7 +17,7 @@ def optmanager():
 @pytest.fixture
 def config_finder():
     """Generate a simple ConfigFileFinder."""
-    return config.ConfigFileFinder('flake8', [], [])
+    return config.ConfigFileFinder('flake8', [], [], [])
 
 
 def test_parse_cli_config(optmanager, config_finder):

--- a/tests/unit/test_merged_config_parser.py
+++ b/tests/unit/test_merged_config_parser.py
@@ -191,7 +191,7 @@ def test_parsed_configs_are_equivalent(
     with mock.patch.object(config_finder, 'local_config_files') as localcfs:
         localcfs.return_value = [config_fixture_path]
         with mock.patch.object(config_finder,
-                               'user_config_file') as usercf:
+                               'user_config_files') as usercf:
             usercf.return_value = []
             parsed_config = parser.merge_user_and_local_config()
 
@@ -223,7 +223,7 @@ def test_parsed_hyphenated_and_underscored_names(
     with mock.patch.object(config_finder, 'local_config_files') as localcfs:
         localcfs.return_value = [config_file]
         with mock.patch.object(config_finder,
-                               'user_config_file') as usercf:
+                               'user_config_files') as usercf:
             usercf.return_value = []
             parsed_config = parser.merge_user_and_local_config()
 


### PR DESCRIPTION
Well this started off clean but the config reading loigic is more tangled than I thought so it is now completely dirty.

This seems to be working fine now but it would need a serious clean-up/simplification to be in a state that can be submitted as a PR to PyCQA.

TODO:
Add tests to validate that the various combinations of config files are given the right precedence for the final config.